### PR TITLE
set bosh_id as a host alias

### DIFF
--- a/jobs/dd-agent/templates/config/datadog.conf.erb
+++ b/jobs/dd-agent/templates/config/datadog.conf.erb
@@ -29,6 +29,9 @@ hostname: <%= spec.name.tr('_', '-') %>-<%= spec.index %>
 <% end %>
 
 cloud_foundry: true
+<% if spec.id and not spec.id.empty? %>
+bosh_id: <%= spec.id %>
+<% end %>
 
 # Set the host's tags
 <%

--- a/jobs/dd-agent/templates/config/datadog.conf.erb
+++ b/jobs/dd-agent/templates/config/datadog.conf.erb
@@ -28,6 +28,8 @@ hostname: <%= hostname %>
 hostname: <%= spec.name.tr('_', '-') %>-<%= spec.index %>
 <% end %>
 
+host_aliases: <%= spec.id if spec.id and not spec.id.empty? %>
+
 # Set the host's tags
 <%
 generated_tags = {}

--- a/jobs/dd-agent/templates/config/datadog.conf.erb
+++ b/jobs/dd-agent/templates/config/datadog.conf.erb
@@ -28,14 +28,7 @@ hostname: <%= hostname %>
 hostname: <%= spec.name.tr('_', '-') %>-<%= spec.index %>
 <% end %>
 
-<%
-  host_aliases = []
-  if spec.id and not spec.id.empty?
-    host_aliases << spec.id
-  end
-%>
-
-host_aliases: <%= host_aliases.join(',') %>
+cloud_foundry: true
 
 # Set the host's tags
 <%

--- a/jobs/dd-agent/templates/config/datadog.conf.erb
+++ b/jobs/dd-agent/templates/config/datadog.conf.erb
@@ -28,7 +28,17 @@ hostname: <%= hostname %>
 hostname: <%= spec.name.tr('_', '-') %>-<%= spec.index %>
 <% end %>
 
-host_aliases: <%= spec.id if spec.id and not spec.id.empty? %>
+<%
+  host_aliases = []
+  if spec.id and not spec.id.empty?
+    host_aliases << spec.id
+  end
+  if spec.ip and not spec.ip.empty?
+    host_aliases << spec.ip
+  end
+%>
+
+host_aliases: <%= host_aliases.join(',') %>
 
 # Set the host's tags
 <%

--- a/jobs/dd-agent/templates/config/datadog.conf.erb
+++ b/jobs/dd-agent/templates/config/datadog.conf.erb
@@ -33,9 +33,6 @@ hostname: <%= spec.name.tr('_', '-') %>-<%= spec.index %>
   if spec.id and not spec.id.empty?
     host_aliases << spec.id
   end
-  if spec.ip and not spec.ip.empty?
-    host_aliases << spec.ip
-  end
 %>
 
 host_aliases: <%= host_aliases.join(',') %>

--- a/jobs/dd-agent/templates/data/properties.sh.erb
+++ b/jobs/dd-agent/templates/data/properties.sh.erb
@@ -3,6 +3,9 @@
 # job name & index of this VM within cluster
 export DEPLOYMENT_NAME="<%= spec.deployment %>"
 
+export DD_BOSH_ID="<%= spec.id %>"
+export CLOUD_FOUNDRY="true"
+
 # e.g. JOB_NAME=redis, JOB_INDEX=0
 export JOB_NAME='<%= name %>'
 export JOB_INDEX="<%= spec.index %>"


### PR DESCRIPTION
### What does this PR do?

This will set bosh_id as a host alias, making host aliasing and consolidation easier.