### PR TITLE
adds options to toggle gohai metadata collection

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -162,3 +162,6 @@ properties:
   dd.integrations:
     default: {}
     description: Agent integration configuration. Each key will have ".yaml" appended to it and the value dumped a file
+  dd.enable_gohai:
+    default: yes
+    description: Enable gohai metadata collection (default: yes)

--- a/jobs/dd-agent/templates/config/datadog.conf.erb
+++ b/jobs/dd-agent/templates/config/datadog.conf.erb
@@ -38,6 +38,8 @@ cloud_foundry: true
 bosh_id: <%= spec.id %>
 <% end %>
 
+enable_gohai: <%= p('dd.enable_gohai', 'yes') %>
+
 # Set the host's tags
 <%
 generated_tags = {}


### PR DESCRIPTION
### What does this PR do?

This adds an option to toggle collecting gohai metadata to the boshrelease

### Motivation

It is a sister to this Pull Request: https://github.com/DataDog/dd-agent/pull/3572
