### PR TITLE
removing all old blobs from config

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,36 +1,4 @@
 ---
-dd-agent/datadog-agent-5.13.0-1.x86_64.rpm:
-  object_id: b62f1af3-eb98-4ff1-b2fe-43fda4b7a6db
-  sha: f8b2818038895b50c1518aa20d288f9f1ba83dec
-  size: 58220295
-dd-agent/datadog-agent_5.13.0-1_amd64.deb:
-  object_id: 1392922a-cafd-4201-aa03-1e57d7266b8f
-  sha: 1e239c49f24cb143807c9fd54e6a5d0bddad3232
-  size: 69379726
-dd-agent/datadog-agent-5.14.0-1.x86_64.rpm:
-  object_id: a6dfa61c-ad2f-443c-8441-d8a6d2bdc408
-  sha: dd274b283a48581299f4b69c61fbe25eef1065a2
-  size: 65091758
-dd-agent/datadog-agent_5.14.0-1_amd64.deb:
-  object_id: 6230bfd3-f257-4432-a72d-d7de54b63747
-  sha: 73804512c414041d1c81823b700910b851407c6a
-  size: 75801938
-dd-agent/datadog-agent-5.17.0-1.x86_64.rpm:
-  object_id: 0acfde40-55a6-459b-a623-40e3581802db
-  sha: 9c4f5b333a763cefb54082d0972691a19bffeb35
-  size: 72988175
-dd-agent/datadog-agent_5.17.0-1_amd64.deb:
-  object_id: c5464969-c288-499d-8bc4-f60ed79c1521
-  sha: 5badc39445fdcc8e32962e7b81c417933a855049
-  size: 84055790
-dd-agent/datadog-agent-5.17.2-1.x86_64.rpm:
-  object_id: 25668bea-de17-4af4-b25e-2d2982fea9c3
-  sha: '0735973116bb2a9529b07c14c900146f8e42da7a'
-  size: 73006088
-dd-agent/datadog-agent_5.17.2-1_amd64.deb:
-  object_id: 2c42f262-185d-4213-a393-4c205bf778cf
-  sha: 54407f4c3f887268dc6b90008760361661c2efa3
-  size: 84098094
 dd-agent/datadog-agent-5.20.0-1.x86_64.rpm:
   object_id: '0847a63c-e700-4d6b-8eb4-0b35f14af744'
   sha: c1e89f878956315756fd703254e26a9002039970


### PR DESCRIPTION
### What does this PR do?

Remove the blobs that aren't gonna be used anymore. It'll speed up builds.
