### PR TITLE
allow user tags to be defined as a comma separated string

### DIFF
--- a/jobs/dd-agent/templates/config/datadog.conf.erb
+++ b/jobs/dd-agent/templates/config/datadog.conf.erb
@@ -57,7 +57,16 @@ end
 # The others are optional, however this one is not, as it figures into our dashboard
 generated_tags["bosh_deployment"] = spec.deployment if spec.deployment and not spec.deployment.empty?
 generated_tags["deployment"] = spec.deployment if spec.deployment and not spec.deployment.empty?
-tags = p('dd.tags', []) + generated_tags.map { |k, v| "#{k}:#{v}" }
+
+custom_tags = []
+if p('dd.tags', []).class == String
+  custom_tags = p('dd.tags', "").split(",")
+else
+  custom_tags = p('dd.tags', [])
+end
+
+tags = custom_tags
+tags += generated_tags.map { |k, v| "#{k}:#{v}" }
 # The firehose nozzle uses this tag, which is frustrating, but we want the data to be able to conform
 tags += ["index:#{spec.id}"] if spec.id and not spec.id.empty?
 tags += ["ip:#{spec.ip}"] if spec.ip and not spec.ip.empty?


### PR DESCRIPTION
### What does this PR do?

In a tile there is no way to define an array. So, for tags, we're using a comma separated string. However, the agent bosh release expects an array. So, instead, we're going to allow both.

### Motivation

We're going to put the agent in the tile!

