### PR TITLE
updates prepare with add blobs for bosh2

### DIFF
--- a/prepare
+++ b/prepare
@@ -36,6 +36,11 @@ exec_download() {
   )
 }
 
+add_blob() {
+  local blob="$1"
+  bosh add-blob ${SRC}/${1} ${1} || true
+}
+
 main() {
   for script in $(pwd)/packages/*/spec ; do
     local base=$(dirname "${script}")
@@ -44,6 +49,7 @@ main() {
         local downloadfile=$(echo $spec | cut -d'@' -f 1)
         local downloadurl=$(echo $spec | cut -d'@' -f 2)
         exec_download "${downloadfile}" "${downloadurl}"
+        add_blob "${downloadfile}"
       done
   done
 }


### PR DESCRIPTION
### What does this PR do?

Bosh 2 requires you to manually add blobs. This will add them in the prepare script.

