### PR TITLE
Fixes process agent and agent metrics

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 dd-agent/datadog-agent-6.1.0-1.x86_64.rpm:
   size: 89453993
   object_id: 9912fe51-4990-4e79-4085-39fbd9c2026d
@@ -6,3 +7,13 @@ dd-agent/datadog-agent_6.1.0-1_amd64.deb:
   size: 92535874
   object_id: 416281dd-54a6-473f-4208-4a907943cad7
   sha: 44e56d0b992b572e38c626aa86f56a326feb7bc3
+=======
+dd-agent/datadog-agent-6.0.3-1.x86_64.rpm:
+  size: 89919227
+  object_id: 48aa8dd6-a7ca-489c-57a3-fc0c9c809601
+  sha: 6c27bfa94808c06cf7afb40e0924c1a3e788d479
+dd-agent/datadog-agent_6.0.3-1_amd64.deb:
+  size: 93045272
+  object_id: 544a5bd7-0d1c-43ba-548f-a7a79493e875
+  sha: b1cedbabcfa9503c0c6d8fcfcc619c98179766dd
+>>>>>>> remove the old blobs

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,19 +1,6 @@
-<<<<<<< HEAD
 dd-agent/datadog-agent-6.1.0-1.x86_64.rpm:
   size: 89453993
-  object_id: 9912fe51-4990-4e79-4085-39fbd9c2026d
   sha: 9cd52aa6acf6ea8197d878b240729d7e8e267564
 dd-agent/datadog-agent_6.1.0-1_amd64.deb:
   size: 92535874
-  object_id: 416281dd-54a6-473f-4208-4a907943cad7
   sha: 44e56d0b992b572e38c626aa86f56a326feb7bc3
-=======
-dd-agent/datadog-agent-6.0.3-1.x86_64.rpm:
-  size: 89919227
-  object_id: 48aa8dd6-a7ca-489c-57a3-fc0c9c809601
-  sha: 6c27bfa94808c06cf7afb40e0924c1a3e788d479
-dd-agent/datadog-agent_6.0.3-1_amd64.deb:
-  size: 93045272
-  object_id: 544a5bd7-0d1c-43ba-548f-a7a79493e875
-  sha: b1cedbabcfa9503c0c6d8fcfcc619c98179766dd
->>>>>>> remove the old blobs

--- a/jobs/dd-agent/templates/bin/agent_ctl
+++ b/jobs/dd-agent/templates/bin/agent_ctl
@@ -40,7 +40,6 @@ case ${1:-help} in
         } >>$LOG_DIR/$COMPONENT.stdout.log \
         2>>$LOG_DIR/$COMPONENT.stderr.log
     ) &
-    # echo $! > $PIDFILE
     echo "$(<${PIDFILE}). Done"
     ;;
   stop)

--- a/jobs/dd-agent/templates/bin/agent_ctl
+++ b/jobs/dd-agent/templates/bin/agent_ctl
@@ -44,7 +44,7 @@ case ${1:-help} in
     ;;
   stop)
     printf_log "Stopping Datadog $COMPONENT: $(<${PIDFILE}). "
-    stop_agent $AGENT_COMMAND
+    stop_agent $DD_AGENT
     kill_and_wait $PIDFILE
     rm -f $PIDFILE
     printf_log "Done"

--- a/jobs/dd-agent/templates/bin/pre-start
+++ b/jobs/dd-agent/templates/bin/pre-start
@@ -10,3 +10,12 @@ source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/setup.sh "dd-agent"
 
 # setup configuration
 source /var/vcap/jobs/dd-agent/config/confd.sh
+
+# Load function lib (alway before setup, there are some global variables needed)
+source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/agent-setup.sh
+
+if [ ! -e /etc/datadog-agent ]; then
+  ln -s $JOB_DIR/config/ /etc/datadog-agent
+fi
+
+ensure_agent_ownership

--- a/jobs/dd-agent/templates/bin/process_agent_ctl
+++ b/jobs/dd-agent/templates/bin/process_agent_ctl
@@ -32,7 +32,8 @@ case ${1:-help} in
     ;;
   stop)
     printf_log "Stopping Datadog $COMPONENT: $(<${PIDFILE}). "
-    kill_and_wait $PIDFILE
+    kill_and_wait $PIDFILE 25 true
+    find_pid_kill_and_wait $DD_PROCESS_AGENT
     printf_log "Done"
     ;;
   *)

--- a/jobs/dd-agent/templates/bin/process_agent_ctl
+++ b/jobs/dd-agent/templates/bin/process_agent_ctl
@@ -15,7 +15,7 @@ source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/lib.sh
 export DD_AGENT_PY_ENV="PYTHONPATH=$PYTHONPATH,LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 export DD_AGENT_PY="$DD_AGENT_PYTHON"
 DD_PROCESS_AGENT="$JOB_DIR/packages/dd-agent/embedded/bin/process-agent"
-PROCESS_AGENT_CMD="$DD_PROCESS_AGENT --config=$JOB_DIR/config/ --pid=$PIDFILE"
+PROCESS_AGENT_CMD="$DD_PROCESS_AGENT --config=$JOB_DIR/config/datadog.yaml --pid=$PIDFILE"
 
 
 case ${1:-help} in
@@ -28,7 +28,6 @@ case ${1:-help} in
         } >>$LOG_DIR/$COMPONENT.stdout.log \
         2>>$LOG_DIR/$COMPONENT.stderr.log
     ) &
-    echo $! > $PIDFILE
     echo "$(<${PIDFILE}). Done"
     ;;
   stop)

--- a/jobs/dd-agent/templates/bin/process_agent_ctl
+++ b/jobs/dd-agent/templates/bin/process_agent_ctl
@@ -12,9 +12,10 @@ source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/setup.sh "dd-agent" "pr
 # Load function lib (alway before setup, there are some global variables needed)
 source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/lib.sh
 
-DD_PROCESS_AGENT="$JOB_DIR/packages/dd-agent/embedded/bin/process-agent"
 export DD_AGENT_PY_ENV="PYTHONPATH=$PYTHONPATH,LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 export DD_AGENT_PY="$DD_AGENT_PYTHON"
+DD_PROCESS_AGENT="$JOB_DIR/packages/dd-agent/embedded/bin/process-agent"
+PROCESS_AGENT_CMD="$DD_PROCESS_AGENT --config=$JOB_DIR/config/ --pid=$PIDFILE"
 
 
 case ${1:-help} in
@@ -23,7 +24,7 @@ case ${1:-help} in
     pid_guard $PIDFILE "dd-agent-$COMPONENT"
     (
         {
-            exec chpst -v -u vcap:vcap "$DD_PROCESS_AGENT" -ddconfig $JOB_DIR/config/datadog.conf
+            exec chpst -v -u vcap:vcap $PROCESS_AGENT_CMD
         } >>$LOG_DIR/$COMPONENT.stdout.log \
         2>>$LOG_DIR/$COMPONENT.stderr.log
     ) &

--- a/jobs/dd-agent/templates/config/confd.sh.erb
+++ b/jobs/dd-agent/templates/config/confd.sh.erb
@@ -94,9 +94,13 @@ function create_dd_instances {
 rm -rf $CONFD_DIR
 mkdir -p $CONFD_DIR
 
+cp -R ${PACKAGES}/dd-agent/etc/conf.d/* $CONFD_DIR/
+
+
 # Process checks
 <% if p('dd.generate_processes') == true || p('dd.generate_processes') =~ (/(true|t|yes|y|1)$/i) %>
-cat <<EOF > "${CONFD_DIR}/process.yaml"
+mkdir -p ${CONFD_DIR}/process.d/
+cat <<EOF > "${CONFD_DIR}/process.d/process.yaml"
 ---
 init_config:
   pid_cache_duration: 120
@@ -126,7 +130,8 @@ EOF
 
 # NTP
 <% if p('dd.generate_ntp_config') == true || p('dd.generate_ntp_config') =~ (/(true|t|yes|y|1)$/i) %>
-cat <<EOF > "${CONFD_DIR}/ntp.yaml"
+mkdir -p ${CONFD_DIR}/ntp.d
+cat <<EOF > "${CONFD_DIR}/ntp.d/ntp.yaml"
 ---
 init_config:
 
@@ -143,7 +148,8 @@ EOF
 
 # Network
 <% if p('dd.generate_network_config') == true || p('dd.generate_network_config') =~ (/(true|t|yes|y|1)$/i) %>
-cat <<EOF > "${CONFD_DIR}/network.yaml"
+mkdir -p ${CONFD_DIR}/network.d/
+cat <<EOF > "${CONFD_DIR}/network.d/network.yaml"
 ---
 init_config:
 
@@ -159,7 +165,8 @@ EOF
 
 # Mounts
 <% if p('dd.generate_disk_config') == true || p('dd.generate_disk_config') =~ (/(true|t|yes|y|1)$/i) %>
-cat <<EOF > "${CONFD_DIR}/disk.yaml"
+mkdir -p ${CONFD_DIR}/disk.d
+cat <<EOF > "${CONFD_DIR}/disk.d/disk.yaml"
 ---
 init_config:
 
@@ -176,7 +183,8 @@ EOF
 
 # Integrations
 <% p("dd.integrations", {}).each do |integration, config| %>
-cat <<'YAML' > "${CONFD_DIR}/<%= integration %>.yaml"
+mkdir -p ${CONFD_DIR}/<%= integration %>.d/
+cat <<'YAML' > "${CONFD_DIR}/<%= integration %>.d/<%= integration %>.yaml"
 <%= YAML.dump(config) %>
 YAML
 

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -403,7 +403,7 @@ process_config:
 #   Only change if the defaults are causing issues.
 #   max_per_message:
 #   Overrides the path to the Agent bin used for getting the hostname. The default is usually fine.
-  dd_agent_bin: /var/vcap/jobs/dd-agent/packages/dd-agent/bin/agent/agent
+  dd_agent_bin: "/var/vcap/jobs/dd-agent/packages/dd-agent/bin/agent/agent"
 #   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
 #   dd_agent_env:
 

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -133,7 +133,7 @@ collect_security_groups: <%= p("dd.collect_security_groups", "no") %>
 
 # The path containing check configuration files
 # By default, uses the conf.d folder located in the agent configuration folder.
-# confd_path:
+confd_path: /var/vcap/jobs/dd-agent/config/conf.d
 
 # The path containing check configuration files
 # By default, uses the conf.d folder located in the agent configuration folder.

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -403,7 +403,7 @@ process_config:
 #   Only change if the defaults are causing issues.
 #   max_per_message:
 #   Overrides the path to the Agent bin used for getting the hostname. The default is usually fine.
-#   dd_agent_bin:
+  dd_agent_bin: /var/vcap/jobs/dd-agent/packages/dd-agent/bin/agent/agent
 #   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
 #   dd_agent_env:
 

--- a/jobs/dd-agent/templates/data/properties.sh.erb
+++ b/jobs/dd-agent/templates/data/properties.sh.erb
@@ -13,3 +13,19 @@ export JOB_INDEX="<%= spec.index %>"
 export JOB_FULL="$JOB_NAME/$JOB_INDEX"
 export JOB_AZ="<%= spec.az %>"
 export JOB_DNS_DOMAIN="<%= spec.dns_domain_name %>"
+
+<%
+  # Force the hostname to whatever you want. (default: auto-detected)
+  # if no hostname is specified, it will just use the name of the VM
+  if p("dd.hostname", nil)
+    hostname = p("dd.hostname", "")
+  elsif p("dd.use_uuid_hostname", false) and spec.id and not spec.id.empty?
+    hostname = spec.id
+  elsif p("dd.friendly_hostname", true)
+    hostname = "#{spec.name.tr('_', '-')}-#{spec.index}"
+  end
+%>
+
+<% if hostname %>
+export DD_HOSTNAME="<%= hostname %>"
+<% end %>

--- a/packages/dd-agent/packaging
+++ b/packages/dd-agent/packaging
@@ -26,6 +26,8 @@ cp -av helpers ${BOSH_INSTALL_TARGET}/
 AGENT_INSTALL_TARGET=${BOSH_INSTALL_TARGET}/agent
 mkdir -p ${AGENT_INSTALL_TARGET}/checks.d
 
+DIST_DIR=${BOSH_INSTALL_TARGET}/bin/agent/dist
+
 mkdir ./extracted-agent
 
 echo "extracting package"
@@ -33,6 +35,7 @@ if [ $OS == "Debian" ]; then
   dpkg -x dd-agent/datadog-agent_${DD_AGENT_VERSION}-1_amd64.deb ./extracted-agent
 
   cp -R ./extracted-agent/opt/datadog-agent/* ${BOSH_INSTALL_TARGET}
+  cp -R ./extracted-agent/etc/datadog-agent ${BOSH_INSTALL_TARGET}/etc
 fi
 
 if [ $OS == "RedHat" ]; then
@@ -40,7 +43,11 @@ if [ $OS == "RedHat" ]; then
     rpm2cpio ../dd-agent/datadog-agent-${DD_AGENT_VERSION}-1.x86_64.rpm | cpio -idmv --no-absolute-filenames
   popd
   cp -R ./extracted-agent/opt/datadog-agent/* ${BOSH_INSTALL_TARGET}
+  cp -R ./extracted-agent/etc/datadog-agent ${BOSH_INSTALL_TARGET}/etc
 fi
+
+mkdir -p $DIST_DIR/conf.d
+cp -R ./extracted-agent/etc/datadog-agent/conf.d $DIST_DIR/conf.d
 
 # Install custom checks
 echo "Adding custom checks ..."
@@ -54,6 +61,13 @@ pushd ${AGENT_INSTALL_TARGET}
   ln -s /var/vcap/jobs/$JOB_NAME/config/conf.d conf.d
   ln -s /var/vcap/jobs/$JOB_NAME/config/datadog.conf datadog.conf
   ln -s /var/vcap/jobs/$JOB_NAME/config/datadog.yaml datadog.yaml
+popd
+pushd ${DIST_DIR}
+  rm -rf conf.d datadog.conf
+  # create the links to the configuration
+  ln -s /var/vcap/jobs/$JOB_NAME/config/datadog.conf datadog.conf
+  ln -s /var/vcap/jobs/$JOB_NAME/config/datadog.yaml datadog.yaml
+
 popd
 
 echo "Fixing broken symbolic links"

--- a/src/helpers/lib.sh
+++ b/src/helpers/lib.sh
@@ -57,10 +57,11 @@ function pid_guard {
 
 
 function wait_pid {
-  local pid=$1
-  local try_kill=$2
-  local timeout=${3:-0}
-  local force=${4:-0}
+  local pidfile $1
+  local pid=$2
+  local try_kill=$3
+  local timeout=${4:-0}
+  local force=${5:-0}
   local countdown=$(( $timeout * 10 ))
 
   if [ -e /proc/$pid ]; then
@@ -108,7 +109,7 @@ function wait_pidfile {
     if [ -z "$pid" ]; then
       die "Unable to get pid from $pidfile"
     fi
-    wait_pid $pid $try_kill $timeout $force
+    wait_pid $pidfile $pid $try_kill $timeout $force
     rm -f $pidfile
   else
     printf_log "Pidfile $pidfile doesn't exist"

--- a/src/helpers/lib.sh
+++ b/src/helpers/lib.sh
@@ -57,14 +57,15 @@ function pid_guard {
 
 
 function wait_pid {
-  local pidfile $1
+  local pidfile=$1
   local pid=$2
   local try_kill=$3
   local timeout=${4:-0}
   local force=${5:-0}
   local countdown=$(( $timeout * 10 ))
+  local ps_out="$(ps ax | grep $pid | grep -v grep)"
 
-  if [ -e /proc/$pid ]; then
+  if [ -e /proc/$pid -o -n "$ps_out" ]; then
     if [ "$try_kill" = "1" ]; then
       echon_log "Killing $pidfile: $pid "
       kill $pid
@@ -77,7 +78,7 @@ function wait_pid {
           if [ "$force" = "1" ]; then
             echo
             printf_log "Kill timed out, using kill -9 on $pid ..."
-            kill -9 $pid
+            printf_log `kill -9 $pid`
             sleep 0.5
           fi
           break
@@ -128,14 +129,14 @@ function kill_and_wait {
     wait_pidfile $pidfile 1 $timeout $force
   else
     # TODO assume $1 is something to grep from 'ps ax'
-    pid="$(ps auwwx | grep "$1" | awk '{print $2}')"
+    pid="$(ps auwwx | grep "'$1'" | awk '{print $2}')"
     wait_pid $pid 1 $timeout $force
   fi
 }
 
 function find_pid_kill_and_wait {
   local find_command=$1
-  local pid=$(find_pid)
+  local pid=$(find_pid $find_command)
   local timeout=${2:-25}
   local force=${3:-1}
 

--- a/src/helpers/setup.sh
+++ b/src/helpers/setup.sh
@@ -53,19 +53,19 @@ export PYTHONHOME="$PACKAGES/$NAME/embedded/"
 
 # Setup log and tmp folders
 export LOG_DIR="/var/vcap/sys/log/$NAME"
-mkdir -p "$LOG_DIR" && chmod 775 "$LOG_DIR" && chown vcap "$LOG_DIR"
+mkdir -p "$LOG_DIR" && chmod 775 "$LOG_DIR" && chown -R vcap "$LOG_DIR"
 
 export RUN_DIR="/var/vcap/sys/run/$NAME"
-mkdir -p "$RUN_DIR" && chmod 775 "$RUN_DIR" && chown vcap "$RUN_DIR"
+mkdir -p "$RUN_DIR" && chmod 775 "$RUN_DIR" && chown -R vcap "$RUN_DIR"
 
 export PIDFILE="${RUN_DIR}/${COMPONENT}.pid"
 
 export TMP_DIR="/var/vcap/sys/tmp/$NAME"
-mkdir -p "$TMP_DIR" && chmod 775 "$TMP_DIR" && chown vcap "$TMP_DIR"
+mkdir -p "$TMP_DIR" && chmod 775 "$TMP_DIR" && chown -R vcap "$TMP_DIR"
 export TMPDIR="$TMP_DIR"
 
 export CONFD_DIR="${JOB_DIR}/config/conf.d"
-mkdir -p "$CONFD_DIR" && chmod 775 "$CONFD_DIR" && chown vcap "$CONFD_DIR"
+mkdir -p "$CONFD_DIR" && chmod 775 "$CONFD_DIR" && chown -R vcap "$CONFD_DIR"
 
 export LANG=POSIX
 

--- a/src/helpers/setup.sh
+++ b/src/helpers/setup.sh
@@ -30,7 +30,7 @@ done
 for package_lib_dir in $(ls -d $PACKAGES/dd-agent/embedded/lib/python*/site-packages 2>/dev/null); do
     LD_LIBRARY_PATH="${package_lib_dir}:${LD_LIBRARY_PATH}"
 done
-export LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 # Python modules
 PYTHONPATH=${PYTHONPATH:-''}
@@ -38,8 +38,18 @@ PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python2.7:${PYTHONPATH}"
 for python_mod_dir in $(ls -d $PACKAGES/dd-agent/embedded/lib/python*/site-packages 2>/dev/null); do
     PYTHONPATH="${python_mod_dir}:${PYTHONPATH}"
 done
-PYTHONPATH="$PACKAGES/$NAME/agent:$PACKAGES/dd-agent/agent/checks/libs:$PACKAGES/$NAME/checks.d:$PYTHONPATH"
-export PYTHONPATH
+PYTHONPATH="$PACKAGES/$NAME/checks.d:$PYTHONPATH"
+PYTHONPATH="$PACKAGES/dd-agent/agent/checks/libs:$PYTHONPATH"
+PYTHONPATH="$PACKAGES/$NAME/agent:$PYTHONPATH"
+PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python27.zip:$PYTHONPATH"
+PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python2.7:$PYTHONPATH"
+PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python2.7/plat-linux2:$PYTHONPATH"
+PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python2.7/lib-tk:$PYTHONPATH"
+PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python2.7/lib-old:$PYTHONPATH"
+PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python2.7/lib-dynload:$PYTHONPATH"
+export PYTHONPATH="$PACKAGES/$NAME/bin/agent/dist:$PYTHONPATH"
+
+export PYTHONHOME="$PACKAGES/$NAME/embedded/"
 
 # Setup log and tmp folders
 export LOG_DIR="/var/vcap/sys/log/$NAME"


### PR DESCRIPTION
### What does this PR do?

There's a handful of things going on in this PR. I'll break them down.

First, the process agent was not working properly. It needed the agent command so that it could query the hostname from the agent. However, this didn't quite work properly, as the agent config wasn't in the default place. The Process Agent command does not let us pass in a config file. So, instead, I symlinked the config file to the place where the agent expects it. This is not a good solution, but it's better than the process agent not working. Hopefully it is only temporary.

The process agent did work if you allowed the agent to detect the default hostname, rather than using the friendly hostname. The reasons for this working are... somewhat unclear to me.

Second, the agent was not properly reporting all of the metrics. Some of the system checks weren't configured, so I copied the proper files into place. And then I used changed where the config files were being put, adding them into their conf.d locations.

Finally, part of the stop script was messed up. It is now fixed. And, some of the ways we were chowning directories was problematic, that's now fixed as well.