### PR TITLE
set all blobs to public read after uploading new ones

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -88,6 +88,7 @@ fi
 ./release
 # make sure we upload the blobs
 bosh upload-blobs
+s3cmd setacl "s3://${BUCKET_NAME}"  --acl-public --recursive
 
 # git commit it and then push it to the repo
 git add .


### PR DESCRIPTION
`bosh` does not allow us to configure `ACLs`. With our current setup this seems like the easiest option to avoid having to manually modify the ACLs