### PR TITLE
we should not ignore the bin folder it is already here

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ blobstore
 releases/datadog-agent/*.tgz
 datadog-agent-release.tgz
 datadog-agent-boshrelease.tgz
-bin/


### PR DESCRIPTION
### What does this PR do?

We had bin in the gitignore, but we don't want that. The bin directory is already a part of the repo, ignoring it is a bad idea and will lead to things not being properly checked in
