### PR TITLE
Fix stop command

### DIFF
--- a/src/helpers/agent-setup.sh
+++ b/src/helpers/agent-setup.sh
@@ -4,12 +4,14 @@ set -u # report the usage of uninitialized variables
 
 # Some tasks that need to be done before the agent is started
 
+
 function ensure_agent_ownership {
   # make sure the agent owns the config directory
   chown -R vcap:vcap "$JOB_DIR/config/"
   # make sure the agent owns its own directory
   chown -R vcap:vcap "$JOB_DIR/packages/dd-agent/"
 }
+
 
 function stop_agent {
   local agent_command=$1
@@ -21,6 +23,7 @@ function stop_agent {
   ) || true
   find_pid_kill_and_wait $1 || true
 }
+
 
 function check_if_running_and_kill {
   local agent_command="$1"

--- a/src/helpers/lib.sh
+++ b/src/helpers/lib.sh
@@ -137,10 +137,16 @@ function kill_and_wait {
 function find_pid_kill_and_wait {
   local find_command=$1
   local pid=$(find_pid $find_command)
-  local timeout=${2:-25}
-  local force=${3:-1}
+  if [[ ! "$pid" || "$pid" == "" ]]; then
+    echo "No such PID exists, skipping the hard kill"
+  else
+    local timeout=${2:-25}
+    local force=${3:-1}
 
-  wait_pid $pid 1 $timeout $force
+    wait_pid $pid 1 $timeout $force
+    echo "killed pid"
+  fi
+
 }
 
 function find_pid {

--- a/src/helpers/lib.sh
+++ b/src/helpers/lib.sh
@@ -5,12 +5,14 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
+
 # Log some info to the Monit Log file
 function log {
   local message=${1}
   local timestamp=`date +%y:%m:%d-%H:%M:%S`
   printf "${timestamp} :: ${message}\n" >> "/var/vcap/sys/log/${NAME}/${COMPONENT:-$NAME}_script.log"
 }
+
 
 # Print a message
 function printf_log {
@@ -19,6 +21,7 @@ function printf_log {
   printf "${timestamp} :: ${message}\n" | tee -a "/var/vcap/sys/log/${NAME}/${COMPONENT:-$NAME}_script.log"
 }
 
+
 # Print a message without \n at the end
 function echon_log {
   local message=${1}
@@ -26,11 +29,13 @@ function echon_log {
   printf "${timestamp} :: ${message} \n" | tee -a "/var/vcap/sys/log/${NAME}/${COMPONENT:-$NAME}_script.log"
 }
 
+
 # Print a message and exit with error
 function die {
   printf_log "$@"
   exit 1
 }
+
 
 # If loaded within monit ctl scripts then pipe output
 # If loaded from 'source ../utils.sh' then normal STDOUT
@@ -78,7 +83,7 @@ function wait_pid {
           if [ "$force" = "1" ]; then
             echo
             printf_log "Kill timed out, using kill -9 on $pid ..."
-            printf_log `kill -9 $pid`
+            kill -9 $pid
             sleep 0.5
           fi
           break
@@ -134,6 +139,7 @@ function kill_and_wait {
   fi
 }
 
+
 function find_pid_kill_and_wait {
   local find_command=$1
   local pid=$(find_pid $find_command)
@@ -146,8 +152,8 @@ function find_pid_kill_and_wait {
     wait_pid $pid 1 $timeout $force
     echo "killed pid"
   fi
-
 }
+
 
 function find_pid {
   local find_command=$1


### PR DESCRIPTION
### What does this PR do?

Fix the stop command on the Bosh Agent. The stop command was hanging. This should resolve it I believe.

I added the force stop because Agent 6 had some issues stopping when we first released it. It now stops properly but a force stop is still a good idea in case it hangs. My theory about the bug is that it was trying to kill a pid that didn't exist and was encountering a sleep that came later in the script.

I think it should be fixed now, but am not certain as I was never able to totally replicate it.

I also fixed a bit of spacing to make it more consistent.
