### PR TITLE
keep default processes in their own file

### DIFF
--- a/jobs/dd-agent/templates/config/confd.sh.erb
+++ b/jobs/dd-agent/templates/config/confd.sh.erb
@@ -100,7 +100,7 @@ cp -R ${PACKAGES}/dd-agent/etc/conf.d/* $CONFD_DIR/
 # Process checks
 <% if p('dd.generate_processes') == true || p('dd.generate_processes') =~ (/(true|t|yes|y|1)$/i) %>
 mkdir -p ${CONFD_DIR}/process.d/
-cat <<EOF > "${CONFD_DIR}/process.d/process.yaml"
+cat <<EOF > "${CONFD_DIR}/process.d/default_process.yaml"
 ---
 init_config:
   pid_cache_duration: 120


### PR DESCRIPTION
### What does this PR do?

Processes should be kept in their own file so that they're not overwritten by user defined ones. This should fix that issue.

