### PR TITLE
fix scripts that should be sourced

### DIFF
--- a/jobs/dd-agent/templates/bin/agent_ctl
+++ b/jobs/dd-agent/templates/bin/agent_ctl
@@ -15,6 +15,8 @@ source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/lib.sh
 # Load function lib (alway before setup, there are some global variables needed)
 source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/agent-setup.sh
 
+source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/ensure_directories.sh
+
 ensure_agent_ownership
 
 # Hardcoded pidfile

--- a/jobs/dd-agent/templates/bin/pre-start
+++ b/jobs/dd-agent/templates/bin/pre-start
@@ -14,6 +14,8 @@ source /var/vcap/jobs/dd-agent/config/confd.sh
 # Load function lib (alway before setup, there are some global variables needed)
 source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/agent-setup.sh
 
+source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/ensure_directories.sh
+
 if [ ! -e /etc/datadog-agent ]; then
   ln -s $JOB_DIR/config/ /etc/datadog-agent
 fi

--- a/src/helpers/agent-setup.sh
+++ b/src/helpers/agent-setup.sh
@@ -38,3 +38,6 @@ function check_if_running_and_kill {
     fi
   fi
 }
+
+set +e
+set +u 

--- a/src/helpers/ensure_directories.sh
+++ b/src/helpers/ensure_directories.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# setup directories for everything
+# separate these so that the setup shell scripts can be sourced by users easier
+mkdir -p "$LOG_DIR" && chmod 775 "$LOG_DIR" && chown -R vcap "$LOG_DIR"
+mkdir -p "$RUN_DIR" && chmod 775 "$RUN_DIR" && chown -R vcap "$RUN_DIR"
+mkdir -p "$TMP_DIR" && chmod 775 "$TMP_DIR" && chown -R vcap "$TMP_DIR"
+mkdir -p "$CONFD_DIR" && chmod 775 "$CONFD_DIR" && chown -R vcap "$CONFD_DIR"
+
+set +e
+set +u

--- a/src/helpers/lib.sh
+++ b/src/helpers/lib.sh
@@ -178,3 +178,6 @@ function check_nfs_mount {
     fi
   fi
 }
+
+set +e
+set +u 

--- a/src/helpers/setup.sh
+++ b/src/helpers/setup.sh
@@ -51,22 +51,17 @@ export PYTHONPATH="$PACKAGES/$NAME/bin/agent/dist:$PYTHONPATH"
 
 export PYTHONHOME="$PACKAGES/$NAME/embedded/"
 
-# Setup log and tmp folders
+# export directories
 export LOG_DIR="/var/vcap/sys/log/$NAME"
-mkdir -p "$LOG_DIR" && chmod 775 "$LOG_DIR" && chown -R vcap "$LOG_DIR"
-
 export RUN_DIR="/var/vcap/sys/run/$NAME"
-mkdir -p "$RUN_DIR" && chmod 775 "$RUN_DIR" && chown -R vcap "$RUN_DIR"
-
 export PIDFILE="${RUN_DIR}/${COMPONENT}.pid"
-
 export TMP_DIR="/var/vcap/sys/tmp/$NAME"
-mkdir -p "$TMP_DIR" && chmod 775 "$TMP_DIR" && chown -R vcap "$TMP_DIR"
 export TMPDIR="$TMP_DIR"
-
 export CONFD_DIR="${JOB_DIR}/config/conf.d"
-mkdir -p "$CONFD_DIR" && chmod 775 "$CONFD_DIR" && chown -R vcap "$CONFD_DIR"
 
 export LANG=POSIX
 
 export DD_AGENT_PYTHON="$JOB_DIR/packages/dd-agent/embedded/bin/python"
+
+set +e
+set +u


### PR DESCRIPTION
### What does this PR do?

Scripts that should be sourced shouldn't pass failure script options to parent shell.

We should also separate out actions from the variable sourcing, so that we can source these as a user and use the agent.
