### PR TITLE
Add option to enable logs agent

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -33,6 +33,9 @@ properties:
   dd.skip_ssl_validation:
     default: no
     description: Skip SSL validation for the Datadog url
+  dd.enable_logs_agent:
+    default: false
+    description: Enable logs agent for integrations
   dd.api_key:
     description: Datadog API key
   dd.additional_api_url_1:

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -1,6 +1,11 @@
 # The host of the Datadog intake server to send Agent data to
 dd_url: <%= p("dd.url", "https://app.datadoghq.com") %>
 
+# Logs agent
+#
+# Logs agent is disabled by default
+logs_enabled: <%= p('dd.enable_logs_agent', false) %>
+
 # The Datadog api key to associate your Agent's data with your organization.
 # Can be found here:
 # https://app.datadoghq.com/account/settings


### PR DESCRIPTION
This PR adds the option to turn on the logs agent. The motivation is detailed in #56. The implementation we went with is to add a property that toggles `logs_enabled` in `datadog.yaml.erb`.