### PR TITLE
Add site option to the agent

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -229,3 +229,6 @@ properties:
   dd.address_tag:
     default: true
     description: "Include the address tag"
+  dd.site:
+    default: "datadoghq.com"
+    description: "The site of the Datadog intake to send Agent data to. Defaults to 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site."

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -11,6 +11,10 @@ api_key: <%= p('dd.api_key') %>
 # proxy. These settings might impact your checks requests, please refer to the
 # specific check documentation for more details.
 
+# The site of the Datadog intake to send Agent data to.
+# Defaults to 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site.
+site: <%= p("dd.site", "datadoghq.com") %>
+
 # Only use a proxy if one is set
 <% if p("dd.proxy.http", false) || p("dd.proxy.https", false) || p("dd.proxy.no_proxy", false) %>
 proxy:


### PR DESCRIPTION
### What does this PR do?

This adds the site option to the agent. We default it to "datadoghq.com". 

### Motivation

We need to enable EU everywhere!

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
