### PR TITLE
Do not create symlink to agent5 config file

### DIFF
--- a/packages/dd-agent/packaging
+++ b/packages/dd-agent/packaging
@@ -59,13 +59,11 @@ pushd ${AGENT_INSTALL_TARGET}
   rm -rf conf.d datadog.conf
   # create the links to the configuration
   ln -s /var/vcap/jobs/$JOB_NAME/config/conf.d conf.d
-  ln -s /var/vcap/jobs/$JOB_NAME/config/datadog.conf datadog.conf
   ln -s /var/vcap/jobs/$JOB_NAME/config/datadog.yaml datadog.yaml
 popd
 pushd ${DIST_DIR}
   rm -rf conf.d datadog.conf
   # create the links to the configuration
-  ln -s /var/vcap/jobs/$JOB_NAME/config/datadog.conf datadog.conf
   ln -s /var/vcap/jobs/$JOB_NAME/config/datadog.yaml datadog.yaml
 
 popd


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

`datadog.conf` is not the configuration file for agent 6 anymore. No need to symlink to it.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?