### PR TITLE
Add logs_enable to template config

### DIFF
--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -445,6 +445,10 @@ additional_endpoints:
 # ecs_agent_url: http://localhost:51678
 #
 
+# Logs agent specific settings
+#
+logs_enabled: <%= p("dd.enable_logs_agent", false) %>
+
 # Process agent specific settings
 #
 process_config:


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Parameter was not added to the template datadog.yaml, even though it's in the specs, so this adds it https://github.com/DataDog/datadog-agent-boshrelease/blob/2a3a3fddcbdc58ac2d1f23c94b6bf023825f9633/jobs/dd-agent/spec#L34-L36

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?