### PR TITLE
Add wrapper helper script around agent binary

### DIFF
--- a/src/helpers/datadog-agent
+++ b/src/helpers/datadog-agent
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/setup.sh "dd-agent" "agent"
+/var/vcap/jobs/dd-agent/packages/dd-agent/bin/agent/agent "$@"


### PR DESCRIPTION
### What does this PR do?

Add a wrapper script around the agent binary to properly set environment variables such as `LD_LIBRARY_PATH`. 
To invoke agent commands, one would simply do `/var/vcap/packages/dd-agent/helpers/datadog-agent <AGENT_SUBCOMMAND`

### Motivation

With the new library for interfacing go and python, the agent command fails if we don't export the correct `LD_LIBRARY_PATH`

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
