### PR TITLE
Allow fully configuring the disk integration

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -188,6 +188,9 @@ properties:
   dd.generate_network_config_excluded_interfaces:
     default: ["lo", "lo0"]
     description: List of the network interfaces to exclude from reporting metrics
+  dd.disk_yaml_config:
+    default: ""
+    description: Disk integration YAML configuration
   dd.generate_disk_config:
     default: yes
     description: Generate disk configuration, disk.yaml

--- a/jobs/dd-agent/templates/config/confd.sh.erb
+++ b/jobs/dd-agent/templates/config/confd.sh.erb
@@ -178,6 +178,11 @@ instances:
       - tracefs
 
 EOF
+<% elsif p('dd.disk_yaml_config') != "" %>
+mkdir -p ${CONFD_DIR}/disk.d
+cat <<EOF > "${CONFD_DIR}/disk.d/disk.yaml"
+<%= p('dd.disk_yaml_config') %>
+EOF
 <% end %>
 
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Provide an additional option in the tile to allow full customization of the disk check configuration

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
