### PR TITLE
Add sitecustomize.py script in packaging to fix python prefixes

### DIFF
--- a/packages/dd-agent/packaging
+++ b/packages/dd-agent/packaging
@@ -101,3 +101,13 @@ pushd ${BOSH_INSTALL_TARGET}/embedded/lib/pkgconfig/
     fi
   done
 popd
+
+
+echo "Fixing python prefixes ..."
+sitecustomize_script="import site
+site.addsitedir('${BOSH_INSTALL_TARGET}/embedded/lib/python2.7/site-packages')
+site.PREFIXES.append('${BOSH_INSTALL_TARGET}/embedded/')
+"
+pushd ${BOSH_INSTALL_TARGET}/embedded/lib/python2.7/
+  echo $sitecustomize_script > sitecustomize.py
+popd

--- a/packages/dd-agent/packaging
+++ b/packages/dd-agent/packaging
@@ -104,10 +104,8 @@ popd
 
 
 echo "Fixing python prefixes ..."
-sitecustomize_script="import site
-site.addsitedir('${BOSH_INSTALL_TARGET}/embedded/lib/python2.7/site-packages')
-site.PREFIXES.append('${BOSH_INSTALL_TARGET}/embedded/')
-"
 pushd ${BOSH_INSTALL_TARGET}/embedded/lib/python2.7/
-  echo $sitecustomize_script > sitecustomize.py
+  echo "import site" >> sitecustomize.py
+  echo "site.addsitedir('${BOSH_INSTALL_TARGET}/embedded/lib/python2.7/site-packages')" >> sitecustomize.py
+  echo "site.PREFIXES.append('${BOSH_INSTALL_TARGET}/embedded/')" >> sitecustomize.py
 popd


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Customize the agent's python prefix. See https://docs.python.org/2/library/site.html

### Motivation

Resolve #87 
This issue happened because google's library uses a `.pth` file to fix the imports, but that file is processed only if it is in the site-packages of the `sys.prefix` folder (cf https://docs.python.org/2/library/site.html).
With this addition,  the `.pth` files can be processed by python and google's python libraries can be imported.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?