### PR TITLE
Fixes broken pip symlink

### DIFF
--- a/packages/dd-agent/packaging
+++ b/packages/dd-agent/packaging
@@ -73,7 +73,8 @@ broken_links="/embedded/bin/bzfgrep
 /embedded/bin/bzcmp
 /embedded/bin/bzless
 /embedded/bin/bzegrep
-/embedded/ssl/cert.pem"
+/embedded/ssl/cert.pem
+/embedded/bin/pip"
 
 for link in $broken_links; do
   rm -f ${BOSH_INSTALL_TARGET}/${link}
@@ -84,6 +85,7 @@ pushd ${BOSH_INSTALL_TARGET}/embedded/bin
   ln -s bzdiff bzcmp
   ln -s bzmore bzless
   ln -s bzgrep bzegrep
+  ln -s pip2 pip
 popd
 
 pushd ${BOSH_INSTALL_TARGET}/embedded/ssl


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fixes broken symlink

### Motivation

Breaking deployment of other bosh releases (in particular rabbitmq errand) 

```
+ . /var/vcap/jobs/broker-registrar/bin/change-permissions  
           ++ '[' -z '' ']'  
           ++ ensure_directories_are_not_world_readable  
           ++ chown -LR vcap:vcap /var/vcap/jobs/broker-registrar  
           chown: cannot dereference '/var/vcap/jobs/broker-registrar/packages/dd-agent/embedded/bin/pip': No such file or directory 
```

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

This is being consumed a Pivotal tile so would need to be released there as well
