### PR TITLE
Fix python2 path loading and ntp check

### DIFF
--- a/jobs/dd-agent/templates/config/confd.sh.erb
+++ b/jobs/dd-agent/templates/config/confd.sh.erb
@@ -139,7 +139,7 @@ instances:
   - host: <%= p("dd.generate_ntp_config_host", "0.ubuntu.pool.ntp.org") %>
     offset_threshold: <%= p("dd.generate_ntp_config_offset_threshold", "60") %>
     min_collection_interval: <%= p("dd.generate_ntp_config_min_collection_interval", "60") %>
-    port: ntp
+    port: 123
     version: 3
     timeout: 30
 

--- a/src/helpers/setup.sh
+++ b/src/helpers/setup.sh
@@ -21,23 +21,17 @@ for package_bin_dir in $(ls -d ${package_dir}/*bin 2>/dev/null); do
   temp_path=${package_bin_dir}:${temp_path}
 done
 export PATH="$PACKAGES/$NAME/checks.d:$PACKAGES/$NAME/agent:$PACKAGES/$NAME/bin:$PACKAGES/$NAME/embedded/bin:$PATH"
-for package_lib_dir in $(ls -d $PACKAGES/dd-agent/embedded/lib 2>/dev/null); do
-    LD_LIBRARY_PATH="${package_lib_dir}:${LD_LIBRARY_PATH}"
-done
-for package_lib_dir in $(ls -d $PACKAGES/dd-agent/embedded/lib/python*/lib-dynload 2>/dev/null); do
-    LD_LIBRARY_PATH="${package_lib_dir}:${LD_LIBRARY_PATH}"
-done
-for package_lib_dir in $(ls -d $PACKAGES/dd-agent/embedded/lib/python*/site-packages 2>/dev/null); do
-    LD_LIBRARY_PATH="${package_lib_dir}:${LD_LIBRARY_PATH}"
-done
+
+LD_LIBRARY_PATH="$PACKAGES/dd-agent/embedded/lib:${LD_LIBRARY_PATH}"
+LD_LIBRARY_PATH="$PACKAGES/dd-agent/embedded/lib/python2.7/lib-dynload:${LD_LIBRARY_PATH}"
+LD_LIBRARY_PATH="$PACKAGES/dd-agent/embedded/lib/python2.7/site-packages:${LD_LIBRARY_PATH}"
+
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 # Python modules
 PYTHONPATH=${PYTHONPATH:-''}
 PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python2.7:${PYTHONPATH}"
-for python_mod_dir in $(ls -d $PACKAGES/dd-agent/embedded/lib/python*/site-packages 2>/dev/null); do
-    PYTHONPATH="${python_mod_dir}:${PYTHONPATH}"
-done
+PYTHONPATH="$PACKAGES/dd-agent/embedded/lib/python2.7/site-packages:${PYTHONPATH}"
 PYTHONPATH="$PACKAGES/$NAME/checks.d:$PYTHONPATH"
 PYTHONPATH="$PACKAGES/dd-agent/agent/checks/libs:$PYTHONPATH"
 PYTHONPATH="$PACKAGES/$NAME/agent:$PYTHONPATH"


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fixes the modification of the PYTHONPATH and fixes the issue with the ntp port not being an integer. 

### Motivation

Python3 paths were being read instead of python2, so for example, when running the process check, the PY3 version of psutil was being read and would trigger an exception. 

Default NTP config was using a string instead of an integer for its port, so the check would fail to load. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

Manually tested