### PR TITLE
Upgrade bosh to Datadog Agent 7

### DIFF
--- a/packages/dd-agent/packaging
+++ b/packages/dd-agent/packaging
@@ -7,7 +7,7 @@
 set -e -x
 
 # Grab the latest versions that are in the directory
-DD_AGENT_VERSION=6.16.0
+DD_AGENT_VERSION=7.16.0
 JOB_NAME="dd-agent"
 BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
 
@@ -79,6 +79,7 @@ broken_links="/embedded/bin/bzfgrep
 /embedded/bin/bzless
 /embedded/bin/bzegrep
 /embedded/ssl/cert.pem
+/embedded/bin/python
 /embedded/bin/pip
 /embedded/bin/2to3"
 
@@ -91,8 +92,9 @@ pushd ${BOSH_INSTALL_TARGET}/embedded/bin
   ln -s bzdiff bzcmp
   ln -s bzmore bzless
   ln -s bzgrep bzegrep
-  ln -s pip2 pip
-  ln -s 2to3-2.7 2to3
+  ln -s python3 python
+  ln -s pip3 pip
+  ln -s 2to3-3.7 2to3
 popd
 
 pushd ${BOSH_INSTALL_TARGET}/embedded/ssl

--- a/packages/dd-agent/spec
+++ b/packages/dd-agent/spec
@@ -2,7 +2,7 @@
 name: dd-agent
 
 files:
-- dd-agent/datadog-agent_6.16.0-1_amd64.deb       # https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_6.16.0-1_amd64.deb
-- dd-agent/datadog-agent-6.16.0-1.x86_64.rpm    #  https://s3.amazonaws.com/yum.datadoghq.com/stable/6/x86_64/datadog-agent-6.16.0-1.x86_64.rpm
+- dd-agent/datadog-agent_7.16.0-1_amd64.deb       # https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_7.16.0-1_amd64.deb
+- dd-agent/datadog-agent-7.16.0-1.x86_64.rpm      # https://s3.amazonaws.com/yum.datadoghq.com/stable/7/x86_64/datadog-agent-7.16.0-1.x86_64.rpm
 - helpers/**/*
 - checks.d/**/*


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

Starts getting ready to ship A7 with the bosh release. 

### Description of the Change

With Datadog A7 including Python3, the symlinks we were updating were out of date. 
Also the s3 link to the rpm bucket is slightly different. `s/6/7`

### Verification Process

I created a bosh release with this and deployed it on two VMs (ubuntu and centos). I ran `find /var/vcap/packages/dd-agent/ xtype l` and `find /var/vcap/jobs/dd-agent/ xtype l` and confirmed things look good.

I also checked the status page and confirmed that there aren't errors. 

### Additional Notes

When the Agent upgrades python versions we'll have to bump the symlink again 😄 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
