### PR TITLE
Fail clearly on improper download URL

### DIFF
--- a/prepare
+++ b/prepare
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 SRC=$(pwd)/blobs
 SHELL=/bin/bash
@@ -31,7 +32,7 @@ exec_download() {
     if [ ! -s "${output}" ]; then
       echo "  Downloading ${url} ..."
       mkdir -p "${package}"
-      curl -L -s "${url}" -o "${output}"
+      curl -L --fail "${url}" -o "${output}"
     fi
   )
 }


### PR DESCRIPTION
### What does this PR do?

Sets the prepare script to fail if any commands in the script fail.
Adds a `--fail` flag to the `curl` command used to download the Agent packages

Previously, if the URL in the spec file (the one pointing to an agent version) was wrong, you'd still get a blob created with an improperly downloaded .deb file. This helps catch that error better and fails with an error message. 

### Verification Process

I ran the `./prepare` script locally with both a good and bad URL in the `spec` file. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
