### PR TITLE
Update detection of when to remove blobs

### DIFF
--- a/prepare
+++ b/prepare
@@ -90,16 +90,15 @@ check_versions() {
 }
 
 remove_stale() {
-  local stale_files=""
   local spec_files=""
   for spec in $(read_spec "${script}"); do
     local downloadfile=$(echo $spec | cut -d'@' -f 1)
     local filename=$(echo $downloadfile | cut -d'/' -f 2)
     spec_files="$filename $spec_files"
   done
+  # Remove any files in blobs/dd-agent that aren't in spec
   for saved_file in $(ls blobs/dd-agent); do
-    res=$(echo "$spec_files" | grep -o -h "$saved_file")
-    if [[ ! "$res" ]]; then
+    if [[ !("$spec_files" =~ .*"$saved_file".*) ]]; then
       bosh remove-blob "dd-agent/$saved_file"
     fi
   done


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

This small PR tidies up the prepare script surrounding the logic for removing stale blobs

`grep` returns a non zero exit code if the there are no matches. With the recent addition of `set -e` to this file, this caused he blobs to not get properly removed, as the script would exit if there was a non zero exit code. 

This uses a regex match instead of executing a command to see if a blob is stale. 

(Also removes an unused variable)

### Verification Process

I changed the agent version in the spec a few times and ran `./prepare` and confirmed the blob file and section in blobs.yml were properly removed

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
