### PR TITLE
Default dogstatsd to on and add options to system-probe yaml

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -124,7 +124,7 @@ properties:
     default: no
     description: Should the jmxfetch agent be started
   dd.use_dogstatsd:
-    default: no
+    default: yes
     description: Should the dogstatsd agent be started for statsd metrics collection
   dd.dogstatsd_port:
     default: 18125

--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -6,7 +6,6 @@ packages:
 templates:
   data/properties.sh.erb: data/properties.sh
   config/datadog.yaml.erb: config/datadog.yaml
-  config/system-probe.yaml.erb: config/system-probe.yaml
   config/confd.sh.erb: config/confd.sh
   bin/process_agent_ctl: bin/process_agent_ctl
   bin/system_probe_ctl: bin/system_probe_ctl

--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -4,14 +4,15 @@ description: Datadog Agent
 packages:
 - dd-agent
 templates:
-  data/properties.sh.erb: data/properties.sh
-  config/datadog.yaml.erb: config/datadog.yaml
   config/confd.sh.erb: config/confd.sh
+  config/datadog.yaml.erb: config/datadog.yaml
+  config/system-probe.yaml.erb: config/system-probe.yaml
+  data/properties.sh.erb: data/properties.sh
+  bin/agent_ctl: bin/agent_ctl
+  bin/pre-start: bin/pre-start
   bin/process_agent_ctl: bin/process_agent_ctl
   bin/system_probe_ctl: bin/system_probe_ctl
   bin/trace_agent_ctl: bin/trace_agent_ctl
-  bin/pre-start: bin/pre-start
-  bin/agent_ctl: bin/agent_ctl
 
 properties:
   dd.url:

--- a/jobs/dd-agent/templates/bin/system_probe_ctl
+++ b/jobs/dd-agent/templates/bin/system_probe_ctl
@@ -19,7 +19,7 @@ source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/lib.sh
 export DD_AGENT_PY_ENV="PYTHONPATH=$PYTHONPATH,LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 export DD_AGENT_PY="$DD_AGENT_PYTHON"
 DD_SYSTEM_PROBE="$JOB_DIR/packages/dd-agent/embedded/bin/system-probe"
-SYSTEM_PROBE_CMD="$DD_SYSTEM_PROBE --config=$JOB_DIR/config/system-probe.yaml --pid=$PIDFILE"
+SYSTEM_PROBE_CMD="$DD_SYSTEM_PROBE --config=$JOB_DIR/config/datadog.yaml --pid=$PIDFILE"
 
 
 case ${1:-help} in

--- a/jobs/dd-agent/templates/bin/system_probe_ctl
+++ b/jobs/dd-agent/templates/bin/system_probe_ctl
@@ -16,10 +16,13 @@ source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/setup.sh "dd-agent" "sy
 # Load function lib (alway before setup, there are some global variables needed)
 source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/lib.sh
 
+# Ensure the directories have the appropriate permissions
+source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/ensure_directories.sh
+
 export DD_AGENT_PY_ENV="PYTHONPATH=$PYTHONPATH,LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 export DD_AGENT_PY="$DD_AGENT_PYTHON"
 DD_SYSTEM_PROBE="$JOB_DIR/packages/dd-agent/embedded/bin/system-probe"
-SYSTEM_PROBE_CMD="$DD_SYSTEM_PROBE --config=$JOB_DIR/config/datadog.yaml --pid=$PIDFILE"
+SYSTEM_PROBE_CMD="$DD_SYSTEM_PROBE --config=$JOB_DIR/config/system-probe.yaml --pid=$PIDFILE"
 
 
 case ${1:-help} in

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -217,7 +217,7 @@ enable_gohai: <%= p('dd.enable_gohai', 'yes') %>
 # DogStatsd
 #
 # If you don't want to enable the DogStatsd server, set this option to no
-<% if p('dd.use_dogstatsd') == true || p('dd.use_dogstatsd') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.use_dogstatsd', true) == true || p('dd.use_dogstatsd', 'yes') =~ (/(true|t|yes|y|1)$/i) %>
 use_dogstatsd: yes
 <% else %>
 use_dogstatsd: no
@@ -532,4 +532,12 @@ apm_config:
   agent_config.each do |key, value|
 %>
 <%= key %>: <%= JSON.dump(value) %>
+<% end %>
+
+<% if p('dd.system_probe_enabled', false) == true || p('dd.system_probe_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
+# System probe specific settings
+system_probe_config:
+  enabled: true
+  sysprobe_socket: /var/vcap/packages/dd-agent/run/sysprobe.sock
+  log_file: /var/vcap/sys/log/dd-agent/system-probe.log
 <% end %>

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -533,11 +533,3 @@ apm_config:
 %>
 <%= key %>: <%= JSON.dump(value) %>
 <% end %>
-
-<% if p('dd.system_probe_enabled', false) == true || p('dd.system_probe_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
-# System probe specific settings
-system_probe_config:
-  enabled: true
-  sysprobe_socket: /var/vcap/packages/dd-agent/run/sysprobe.sock
-  log_file: /var/vcap/sys/log/dd-agent/system-probe.log
-<% end %>

--- a/jobs/dd-agent/templates/config/system-probe.yaml.erb
+++ b/jobs/dd-agent/templates/config/system-probe.yaml.erb
@@ -1,7 +1,0 @@
-<% if p('dd.system_probe_enabled', false) == true || p('dd.system_probe_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
-# System probe specific settings
-system_probe_config:
-  enabled: true
-  sysprobe_socket: /var/vcap/packages/dd-agent/run/sysprobe.sock
-  log_file: /var/vcap/sys/log/dd-agent/system-probe.log
-<% end %>

--- a/jobs/dd-agent/templates/config/system-probe.yaml.erb
+++ b/jobs/dd-agent/templates/config/system-probe.yaml.erb
@@ -1,0 +1,16 @@
+# Duplicate any fields required by the process agent from the main datadog.yaml file here
+# Logging
+#
+log_level: <%= p("dd.log_level", "INFO") %>
+
+# Dogstatsd
+dogstatsd_port: <%= p("dd.dogstatsd_port", "18125") %>
+
+# Dedicated system probe section
+<% if p('dd.system_probe_enabled', false) == true || p('dd.system_probe_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
+# System probe specific settings
+system_probe_config:
+  enabled: true
+  sysprobe_socket: /var/vcap/packages/dd-agent/run/sysprobe.sock
+  log_file: /var/vcap/sys/log/dd-agent/system-probe.log
+<% end %>

--- a/src/helpers/agent-setup.sh
+++ b/src/helpers/agent-setup.sh
@@ -16,7 +16,7 @@ function ensure_agent_ownership {
   # make sure the agent owns its own directory
   chown -R vcap:vcap "$JOB_DIR/packages/dd-agent/"
   # make sure that root owns the system probe config
-  chown root:root "$JOB_DIR/config/system-probe.yaml" && chmod +r "$JOB_DIR/config/system-probe.yaml"
+  chown root:root "$JOB_DIR/config/system-probe.yaml" && chmod 0644 "$JOB_DIR/config/system-probe.yaml"
 }
 
 

--- a/src/helpers/agent-setup.sh
+++ b/src/helpers/agent-setup.sh
@@ -15,6 +15,8 @@ function ensure_agent_ownership {
   chown -R vcap:vcap "$JOB_DIR/config/"
   # make sure the agent owns its own directory
   chown -R vcap:vcap "$JOB_DIR/packages/dd-agent/"
+  # make sure that root owns the system probe config
+  chown root:root "$JOB_DIR/config/system-probe.yaml" && chmod +r "$JOB_DIR/config/system-probe.yaml"
 }
 
 

--- a/src/helpers/ensure_directories.sh
+++ b/src/helpers/ensure_directories.sh
@@ -14,8 +14,5 @@ mkdir -p "$RUN_DIR" && chmod 775 "$RUN_DIR" && chown -R vcap "$RUN_DIR"
 mkdir -p "$TMP_DIR" && chmod 775 "$TMP_DIR" && chown -R vcap "$TMP_DIR"
 mkdir -p "$CONFD_DIR" && chmod 775 "$CONFD_DIR" && chown -R vcap "$CONFD_DIR"
 
-# System probe runs as root, so set the config file for this to be writable only by root
-chown root:root "$JOB_DIR/config/system-probe.yaml" && chmod +r "$JOB_DIR/config/system-probe.yaml"
-
 set +e
 set +u

--- a/src/helpers/ensure_directories.sh
+++ b/src/helpers/ensure_directories.sh
@@ -14,5 +14,8 @@ mkdir -p "$RUN_DIR" && chmod 775 "$RUN_DIR" && chown -R vcap "$RUN_DIR"
 mkdir -p "$TMP_DIR" && chmod 775 "$TMP_DIR" && chown -R vcap "$TMP_DIR"
 mkdir -p "$CONFD_DIR" && chmod 775 "$CONFD_DIR" && chown -R vcap "$CONFD_DIR"
 
+# System probe runs as root, so set the config file for this to be writable only by root
+chown root:root "$JOB_DIR/config/system-probe.yaml" && chmod +r "$JOB_DIR/config/system-probe.yaml"
+
 set +e
 set +u


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

Sets the dogstatsd binary to enabled by default (its what the tile does - https://github.com/DataDog/datadog-cluster-monitoring-pivotal-tile/blob/bdaa892efe8bbfca919bec4a9fed8f3e693a3743/tile/tile.yml#L437)

Duplicate some config options in the system_probe.yaml file

### Description of the Change

The Datadog Agent binaries, trace, process, system_probe, etc each submit telemetry data through dogstatsd about the health of the binary. Since the system probe contents were in a dedicated yaml file, the system probe + process binaries weren't picking up the modified dogstatsd port, thus not sending the telemetry data. 

### Alternate Designs

Originally, I merged the system probe yaml into the datadog agent yaml, but the datadog docs recommend to have these be separate. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
