### PR TITLE
Fixed hostname generation issue

### DIFF
--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -85,11 +85,13 @@ skip_ssl_validation: <%= p("dd.skip_ssl_validation", "no") %>
   elsif p("dd.use_uuid_hostname", false) and spec.id and not spec.id.empty?
     hostname = spec.id
   elsif p("dd.friendly_hostname", true)
-    hostname = "#{spec.name.tr('_', '-')}-#{spec.index}"
+    hostname = "#{spec.name}-#{spec.index}"
     if p("dd.unique_friendly_hostname", false)
       hostname = "#{hostname}-#{spec.deployment}"
     end
   end
+
+  hostname = hostname.tr('_', '-')
 %>
 
 cf_os_hostname_aliasing: <%= p('dd.cf_os_hostname_aliasing', false) %>


### PR DESCRIPTION
### What does this PR do?

Fixes the hostname generation in bosh release to generate RFC1123 compliant hostnames.

[](https://datadoghq.atlassian.net/browse/ITL-562)

### Description of the Change
Transforming all underscores `_` into dashes `-` after hostname generation

### Verification Process

Deployed the new package to the TKGI tile with the updated runtime-config.yml, the agent status doesn't display the error anymore, and the hostnames are compliant with the RFC1123.