### PR TITLE
Fix appending VM GUID to friendly hostname

### DIFF
--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -89,7 +89,7 @@ skip_ssl_validation: <%= p("dd.skip_ssl_validation", "no") %>
     if p("dd.unique_friendly_hostname", false)
       hostname = "#{hostname}-#{spec.deployment}"
     end
-    if p("dd.friendly_hostname_append_vm_uuid", false)
+    if p("dd.friendly_hostname_append_vm_guid", false)
       hostname = "#{hostname}-#{spec.id}"
     end
   end


### PR DESCRIPTION
Property name is `...-guid`: https://github.com/DataDog/datadog-agent-boshrelease/blob/41bfe6e40debba3e001fb6169b14c942154de47d/jobs/dd-agent/spec#L76