### PR TITLE
Add properties to configure custom URLs for process, APM and logs

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -16,7 +16,13 @@ templates:
 
 properties:
   dd.url:
-    description: The host of the Datadog intake server to send Agent data to
+    description: The host of the Datadog intake server for metrics
+  dd.logs_dd_url:
+    description: The host of the Datadog intake server for logs
+  dd.apm_dd_url:
+    description: The host of the Datadog intake server for APM data
+  dd.process_dd_url:
+    description: The host of the Datadog intake server for process data
   dd.proxy:
     description: Proxy settings to connect to the Internet
     example:

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -480,9 +480,19 @@ additional_endpoints:
 # ecs_agent_url: http://localhost:51678
 #
 
+# Logs agent specific settings
+#
+logs_config:
+<% if p('dd.logs_dd_url') %>
+  logs_dd_url: <%= p('dd.logs_dd_url') %>
+<% end %>
+
 # Process agent specific settings
 #
 process_config:
+<% if p('dd.process_dd_url') %>
+  process_dd_url: <%= p('dd.process_dd_url') %>
+<% end %>
 #   Note: the Process Agent expects this to be a string
 <% if p('dd.process_agent_enabled', false) == true || p('dd.process_agent_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
   enabled: true
@@ -518,6 +528,9 @@ process_config:
 # Trace Agent Specific Settings
 #
 apm_config:
+<% if p('dd.apm_dd_url') %>
+  apm_dd_url: <%= p('dd.apm_dd_url') %>
+<% end %>
 #   Whether or not the APM Agent should run
 <% if p('dd.trace_agent_enabled', false) == true || p('dd.trace_agent_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
   enabled: true


### PR DESCRIPTION
The `dd.url` property only configures the metrics endpoint