### PR TITLE
Always set `no_proxy_nonexact_match` option if specified

### DIFF
--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -47,8 +47,8 @@ proxy:
   <% end %>
 <% end %>
 
-<% if p("dd.no_proxy_nonexact_match", false) %>
-no_proxy_nonexact_match: <%= p("dd.no_proxy_nonexact_match") %>
+<% if_p("dd.no_proxy_nonexact_match") do |no_proxy_nonexact_match| %>
+no_proxy_nonexact_match: <%= no_proxy_nonexact_match %>
 <% end %>
 
 <%


### PR DESCRIPTION
Fixes the issue where setting the value to false explicitly would not write it in the agent configuration