### PR TITLE
Add option to collect monit children processes in process check

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -180,6 +180,9 @@ properties:
   dd.generate_monit_processes:
     default: yes
     description: Add monit processes to process check
+  dd.collect_monit_children_processes:
+    default: false
+    description: Enable collection of children processes of monit processes
   dd.generate_system_processes:
     default: yes
     description: Add basic system processes to process check

--- a/jobs/dd-agent/templates/config/confd.sh.erb
+++ b/jobs/dd-agent/templates/config/confd.sh.erb
@@ -86,6 +86,7 @@ function create_dd_instances {
         for entry in $(get_monit_services "${monit}"); do
             # format: registry|/var/vcap/sys/run/registry/registry.pid
             echo "  - name: ${entry%|*}"
+            echo      collect_children: <%= p('dd.collect_monit_children_processes', false) %>
             echo "    pid_file: ${entry#*|}"
             echo
         done

--- a/jobs/dd-agent/templates/config/confd.sh.erb
+++ b/jobs/dd-agent/templates/config/confd.sh.erb
@@ -86,7 +86,7 @@ function create_dd_instances {
         for entry in $(get_monit_services "${monit}"); do
             # format: registry|/var/vcap/sys/run/registry/registry.pid
             echo "  - name: ${entry%|*}"
-            echo      collect_children: <%= p('dd.collect_monit_children_processes', false) %>
+            echo "    collect_children: <%= p('dd.collect_monit_children_processes', false) %>"
             echo "    pid_file: ${entry#*|}"
             echo
         done


### PR DESCRIPTION
<!--
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--
What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.
-->

Add an option to collect children monit processes. Can be useful when `monit` control scripts fork to run the actual process, and still have visibility on the overall resource usage of such processes.

