### PR TITLE
Fix option to enable/disable trace agent

### DIFF
--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -546,6 +546,8 @@ apm_config:
 #   Whether or not the APM Agent should run
 <% if p('dd.trace_agent_enabled', false) == true || p('dd.trace_agent_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
   enabled: true
+<% else %>
+  enabled: false
 <% end %>
 #   The full path to the file where trace-agent logs will be written.
   log_file: /var/vcap/sys/log/dd-agent/trace_agent.log


### PR DESCRIPTION
We must explicitly set `apm_config.enabled` to `false` to disable the trace agent.