### PR TITLE
Fix template rendering on BOSH directors running Ruby 3.2

### DIFF
--- a/jobs/dd-agent/monit
+++ b/jobs/dd-agent/monit
@@ -4,7 +4,7 @@ check process datadog-agent
   stop program "/var/vcap/jobs/dd-agent/bin/agent_ctl stop" with timeout 90 seconds
   group vcap
 
-<% if p('dd.process_agent_enabled', false) == true || p('dd.process_agent_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.process_agent_enabled', false) == true || p('dd.process_agent_enabled', false).to_s =~ (/(true|t|yes|y|1)$/i) %>
 check process dd-agent-process-agent
   with pidfile /var/vcap/sys/run/dd-agent/process_agent.pid
   start program "/var/vcap/jobs/dd-agent/bin/process_agent_ctl start"
@@ -12,7 +12,7 @@ check process dd-agent-process-agent
   group vcap
 <% end %>
 
-<% if p('dd.trace_agent_enabled', false) == true || p('dd.trace_agent_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.trace_agent_enabled', false) == true || p('dd.trace_agent_enabled', false).to_s =~ (/(true|t|yes|y|1)$/i) %>
 check process dd-agent-trace-agent
   with pidfile /var/vcap/sys/run/dd-agent/trace_agent.pid
   start program "/var/vcap/jobs/dd-agent/bin/trace_agent_ctl start"
@@ -20,7 +20,7 @@ check process dd-agent-trace-agent
   group vcap
 <% end %>
 
-<% if p('dd.system_probe_enabled', false) == true || p('dd.system_probe_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.system_probe_enabled', false) == true || p('dd.system_probe_enabled', false).to_s =~ (/(true|t|yes|y|1)$/i) %>
 check process dd-agent-system-probe
   with pidfile /var/vcap/sys/run/dd-agent/system-probe.pid
   start program "/var/vcap/jobs/dd-agent/bin/system_probe_ctl start"

--- a/jobs/dd-agent/templates/config/confd.sh.erb
+++ b/jobs/dd-agent/templates/config/confd.sh.erb
@@ -103,7 +103,7 @@ cp -R ${PACKAGES}/dd-agent/etc/conf.d/* $CONFD_DIR/
 
 
 # Process checks
-<% if p('dd.generate_processes') == true || p('dd.generate_processes') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.generate_processes') == true || p('dd.generate_processes').to_s =~ (/(true|t|yes|y|1)$/i) %>
 mkdir -p ${CONFD_DIR}/process.d/
 cat <<EOF > "${CONFD_DIR}/process.d/default_process.yaml"
 ---
@@ -111,10 +111,10 @@ init_config:
   pid_cache_duration: 120
 
 instances:
-<% if p('dd.generate_monit_processes') == true || p('dd.generate_monit_processes') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.generate_monit_processes') == true || p('dd.generate_monit_processes').to_s =~ (/(true|t|yes|y|1)$/i) %>
 $(create_dd_instances "$JOBS_DIR")
 <% end %>
-<% if p('dd.generate_system_processes') == true || p('dd.generate_system_processes') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.generate_system_processes') == true || p('dd.generate_system_processes').to_s =~ (/(true|t|yes|y|1)$/i) %>
   - name: sshd
     exact_match: false
     search_string:
@@ -134,7 +134,7 @@ EOF
 
 
 # NTP
-<% if p('dd.generate_ntp_config') == true || p('dd.generate_ntp_config') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.generate_ntp_config') == true || p('dd.generate_ntp_config').to_s =~ (/(true|t|yes|y|1)$/i) %>
 mkdir -p ${CONFD_DIR}/ntp.d
 cat <<EOF > "${CONFD_DIR}/ntp.d/ntp.yaml"
 ---
@@ -152,7 +152,7 @@ EOF
 <% end %>
 
 # Network
-<% if p('dd.generate_network_config') == true || p('dd.generate_network_config') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.generate_network_config') == true || p('dd.generate_network_config').to_s =~ (/(true|t|yes|y|1)$/i) %>
 mkdir -p ${CONFD_DIR}/network.d/
 cat <<EOF > "${CONFD_DIR}/network.d/network.yaml"
 ---
@@ -169,7 +169,7 @@ EOF
 <% end %>
 
 # Mounts
-<% if p('dd.generate_disk_config') == true || p('dd.generate_disk_config') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.generate_disk_config') == true || p('dd.generate_disk_config').to_s =~ (/(true|t|yes|y|1)$/i) %>
 mkdir -p ${CONFD_DIR}/disk.d
 cat <<EOF > "${CONFD_DIR}/disk.d/disk.yaml"
 ---

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -117,7 +117,7 @@ bosh_id: <%= spec.id %>
 # Set the host's tags
 <%
 generated_tags = {}
-if p('dd.bosh_tags') == true || p('dd.bosh_tags') =~ (/(true|t|yes|y|1)$/i)
+if p('dd.bosh_tags') == true || p('dd.bosh_tags').to_s =~ (/(true|t|yes|y|1)$/i)
     bosh_tags_prefix=p('dd.bosh_tags_prefix', 'bosh_')
     generated_tags["#{bosh_tags_prefix}id"] = spec.id if spec.id and not spec.id.empty?
     generated_tags["#{bosh_tags_prefix}job"] = spec.name if spec.name and not spec.name.empty?
@@ -222,7 +222,7 @@ check_runners: <%= p('dd.check_runners', 1) %>
 # Metadata collection should always be enabled, except if you are running several
 # agents/dsd instances per host. In that case, only one agent should have it on.
 # WARNING: disabling it on every agent will lead to display and billing issues
-<% if p('dd.enable_metadata_collection') == true || p('dd.enable_metadata_collection') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.enable_metadata_collection') == true || p('dd.enable_metadata_collection').to_s =~ (/(true|t|yes|y|1)$/i) %>
 enable_metadata_collection: yes
 <% else %>
 enable_metadata_collection: no
@@ -245,7 +245,7 @@ enable_gohai: <%= p('dd.enable_gohai', 'yes') %>
 # DogStatsd
 #
 # If you don't want to enable the DogStatsd server, set this option to no
-<% if p('dd.use_dogstatsd', true) == true || p('dd.use_dogstatsd', 'yes') =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.use_dogstatsd', true) == true || p('dd.use_dogstatsd', 'yes').to_s =~ (/(true|t|yes|y|1)$/i) %>
 use_dogstatsd: yes
 <% else %>
 use_dogstatsd: no
@@ -500,8 +500,8 @@ process_config:
   process_dd_url: <%= url %>
 <% end %>
 #   Note: the Process Agent expects this to be a string
-<% if p('dd.process_agent_enabled', false) == true || p('dd.process_agent_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
-  <% if p('dd.process_agent_containers_only', false) == true || p('dd.process_agent_containers_only', false) =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.process_agent_enabled', false) == true || p('dd.process_agent_enabled', false).to_s =~ (/(true|t|yes|y|1)$/i) %>
+  <% if p('dd.process_agent_containers_only', false) == true || p('dd.process_agent_containers_only', false).to_s =~ (/(true|t|yes|y|1)$/i) %>
   enabled: "false"
   <% else %>
   enabled: "true"
@@ -511,7 +511,7 @@ process_config:
 <% end %>
 #   The full path to the file where process-agent logs will be written.
   log_file: /var/vcap/sys/log/dd-agent/process_agent.log
-<% if p('dd.strip_proc_arguments', false) == true || p('dd.strip_proc_arguments', false) =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.strip_proc_arguments', false) == true || p('dd.strip_proc_arguments', false).to_s =~ (/(true|t|yes|y|1)$/i) %>
   strip_proc_arguments: true
 <% end %>
 #   The interval, in seconds, at which we will run each check. If you want consistent
@@ -544,7 +544,7 @@ apm_config:
   apm_dd_url: <%= url %>
 <% end %>
 #   Whether or not the APM Agent should run
-<% if p('dd.trace_agent_enabled', false) == true || p('dd.trace_agent_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.trace_agent_enabled', false) == true || p('dd.trace_agent_enabled', false).to_s =~ (/(true|t|yes|y|1)$/i) %>
   enabled: true
 <% else %>
   enabled: false

--- a/jobs/dd-agent/templates/config/system-probe.yaml.erb
+++ b/jobs/dd-agent/templates/config/system-probe.yaml.erb
@@ -9,7 +9,7 @@ force_tls_12: <%= p("dd.force_tls_12") %>
 dogstatsd_port: <%= p("dd.dogstatsd_port", "18125") %>
 
 # Dedicated system probe section
-<% if p('dd.system_probe_enabled', false) == true || p('dd.system_probe_enabled', false) =~ (/(true|t|yes|y|1)$/i) %>
+<% if p('dd.system_probe_enabled', false) == true || p('dd.system_probe_enabled', false).to_s =~ (/(true|t|yes|y|1)$/i) %>
 # System probe specific settings
 system_probe_config:
   enabled: true


### PR DESCRIPTION
### What does this PR do?

Fix failures when rendering templates with a BOSH director running Ruby 3.2

https://github.com/cloudfoundry/bosh/issues/2424

### Description of the Change

Ruby 3.2 removed `=~` from Kernel, so the left hand side needs to be a string or regex Calling `=~` on `false` or `true` used to always just return nil, which was not always correct. Now it raises an error.

Convering the values to strings first should produce the correct behavior.

### Verification Process

Tested `=~` behavior in Ruby 3.1 and 3.2 IRB shells

### Additional Notes

https://bugs.ruby-lang.org/issues/15231

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
