### PR TITLE
Add `dd.run_path` property

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -286,6 +286,9 @@ properties:
   dd.cluster_agent_poll_interval:
     default: 10
     description: How often to poll the Cluster Agent for new config checks (in seconds).
+  dd.run_path:
+    default: /var/vcap/jobs/dd-agent/packages/dd-agent/run
+    description: Path to the run folder of the agent.
   container_tagger.retry_count:
     default: 10
     description: How many attempts the Agent tries to inject tags in a Container.

--- a/jobs/dd-agent/templates/config/datadog.yaml.erb
+++ b/jobs/dd-agent/templates/config/datadog.yaml.erb
@@ -3,6 +3,11 @@
 dd_url: <%= p("dd.url") %>
 <% end %>
 
+<%# run_path needs to be correctly set for remote config to work %>
+<% if p("dd.run_path") %>
+run_path: <%= p("dd.run_path") %>
+<% end %>
+
 # Logs agent
 #
 # Logs agent is disabled by default


### PR DESCRIPTION
Adds `dd.run_path` property and fixes the default location of the `run_path` datadog agent property which is used by remote config.