### PR TITLE
Fix trace_agent_ctl deprecated flag in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.16.0 / 2023-11-20
+
+* [Fixed] Fix trace_agent_ctl fails to start. Deprecated pid flag being used. Updated to --pidfile.
+
 ## 4.16.0 / 2023-11-13
 
 * [Added] Bump embedded Datadog Agent version to 7.48.0. Read more about it [here](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7480--6480).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.16.0 / 2023-11-20
 
-* [Fixed] Fix trace_agent_ctl fails to start. Deprecated pid flag being used. Updated to --pidfile. See [#209](https://github.com/DataDog/datadog-agent-boshrelease/pull/209)
+* [Fixed] Fix `trace_agent_ctl` failing to start. Deprecated the `pid` flag being used, and upgraded to `--pidfile`. See [#209](https://github.com/DataDog/datadog-agent-boshrelease/pull/209).
 
 ## 4.16.0 / 2023-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 4.16.0 / 2023-11-20
-
-* [Fixed] Fix `trace_agent_ctl` failing to start. Deprecated the `pid` flag being used, and upgraded to `--pidfile`. See [#209](https://github.com/DataDog/datadog-agent-boshrelease/pull/209).
-
 ## 4.16.0 / 2023-11-13
 
 * [Added] Bump embedded Datadog Agent version to 7.48.0. Read more about it [here](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7480--6480).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.16.0 / 2023-11-20
 
-* [Fixed] Fix trace_agent_ctl fails to start. Deprecated pid flag being used. Updated to --pidfile.
+* [Fixed] Fix trace_agent_ctl fails to start. Deprecated pid flag being used. Updated to --pidfile. See [#209](https://github.com/DataDog/datadog-agent-boshrelease/pull/209)
 
 ## 4.16.0 / 2023-11-13
 

--- a/jobs/dd-agent/templates/bin/trace_agent_ctl
+++ b/jobs/dd-agent/templates/bin/trace_agent_ctl
@@ -17,7 +17,7 @@ source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/setup.sh "dd-agent" "tr
 source /var/vcap/jobs/dd-agent/packages/dd-agent/helpers/lib.sh
 
 DD_TRACE_AGENT="$JOB_DIR/packages/dd-agent/embedded/bin/trace-agent"
-TRACE_AGENT_CMD="$DD_TRACE_AGENT --config=$JOB_DIR/config/datadog.yaml --pid=$PIDFILE"
+TRACE_AGENT_CMD="$DD_TRACE_AGENT --config=$JOB_DIR/config/datadog.yaml --pidfile=$PIDFILE"
 
 
 case ${1:-help} in


### PR DESCRIPTION
<!--
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

trace_agent_ctl fails to run in monit.
Run command has a depreicated flag for pid

### Description of the Change

Update the --pid flag to --pidfile due to deprecation of old flag and process fails.

### Alternate Designs
NA

### Possible Drawbacks
NA

### Verification Process

I have tested this manually on a bosh deployed VM. The monit process loads with the new flag suggested in the help of the command.

### Additional Notes
NA

### Release Notes

<!--
If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.
-->

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
