### PR TITLE
Enable installing extra integrations not included in Agent package

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -6,6 +6,7 @@ packages:
 templates:
   config/confd.sh.erb: config/confd.sh
   config/datadog.yaml.erb: config/datadog.yaml
+  config/extra-integrations.sh.erb: config/extra-integrations.sh
   config/system-probe.yaml.erb: config/system-probe.yaml
   config/bpm.yml.erb: config/bpm.yml
   data/properties.sh.erb: data/properties.sh
@@ -238,6 +239,9 @@ properties:
   dd.integrations:
     default: {}
     description: Agent integration configuration. Each key will have ".yaml" appended to it and the value dumped a file
+  dd.extra_integrations:
+    default: {}
+    description: Additional agent integrations to be installed. Each key should be the integration name and the value should be the integration version; the integration configuration has to be added to `dd.integrations` property
   dd.expvar_port:
     default: 15000
     description: The port that the agent reports expvar metrics over. (Set to a different port if there's a collision)

--- a/jobs/dd-agent/templates/bin/pre-start
+++ b/jobs/dd-agent/templates/bin/pre-start
@@ -27,5 +27,8 @@ fi
 
 ensure_agent_ownership
 
+# Install additional integrations
+source /var/vcap/jobs/dd-agent/config/extra-integrations.sh
+
 # sysctl -e -w net.ipv4.tcp_fin_timeout 10
 # sysctl -e -w net.ipv4.tcp_tw_reuse 1

--- a/jobs/dd-agent/templates/config/extra-integrations.sh.erb
+++ b/jobs/dd-agent/templates/config/extra-integrations.sh.erb
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+DD_AGENT="$JOB_DIR/packages/dd-agent/bin/agent/agent"
+
+<% p("dd.extra_integrations", {}).each do |integration, version| %>
+(cd ${JOB_DIR}/packages/dd-agent && exec chpst -v -u vcap:vcap ${DD_AGENT} integration install -t datadog-<%= integration %>==<%= version %>)
+<% end %>


### PR DESCRIPTION
### What does this PR do?

Enables installing extra (community) integrations that are not included in the default agent package.

### Description of the Change

The extra integrations are listed in dd.extra_integrations property of dd-agent job. The actual setup is done by a shell script called from the pre-start script.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
