### PR TITLE
Add additional volumes to the datadog-agent BPM process

### DIFF
--- a/jobs/dd-agent/templates/config/bpm.yml.erb
+++ b/jobs/dd-agent/templates/config/bpm.yml.erb
@@ -18,6 +18,8 @@ processes:
       - path: /var/vcap/jobs/dd-agent/packages/dd-agent/embedded/*
         writable: true
         allow_executions: true
+      - path: /var/vcap/store
+      - path: /var/vcap/data
     limits:
 <% if p("bpm.agent.memory") != "" %>
       memory: <%= p("bpm.agent.memory") %>


### PR DESCRIPTION
<!--
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

Adds `/var/vcap/store` and `/var/vcap/data` paths to the datadog-agent BPM process in order to improve the filesystem detection in the disk integration.

<!--
What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.
-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--
If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.
-->

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
