### PR TITLE
[ARTSEC-INT] Update datadog-agent-buildimages to v102144341-64dad9f8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
 
 agent-bosh-prod-release:
   stage: deploy
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:v48815877-9bfad02c
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:v102144341-64dad9f8
   tags: ["runner:main"]
   when: manual
   script:


### PR DESCRIPTION
Update stale buildimages reference from v48815877-9bfad02c to v102144341-64dad9f8.