### PR TITLE
fix(dd-agent): move bpm chmod +x from pre-start to post-start

### DIFF
--- a/jobs/dd-agent/spec
+++ b/jobs/dd-agent/spec
@@ -11,6 +11,7 @@ templates:
   config/bpm.yml.erb: config/bpm.yml
   data/properties.sh.erb: data/properties.sh
   bin/pre-start: bin/pre-start
+  bin/post-start: bin/post-start
   bin/agent_ctl: bin/agent_ctl
   bin/process_agent_ctl: bin/process_agent_ctl
   bin/trace_agent_ctl: bin/trace_agent_ctl

--- a/jobs/dd-agent/templates/bin/post-start
+++ b/jobs/dd-agent/templates/bin/post-start
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017-Present Datadog, Inc.
+
+set -e
+set -u
+
+# Add execute flags to any directory inside the bpm run folder, so that the agent can read pidfiles inside.
+# This runs as a post-start so that BPM job directories created when starting BPM-managed processes
+# (including any future BPM job added to this release) exist by the time we chmod them.
+find /var/vcap/sys/run/bpm -type d -print0 | xargs -0 chmod +x || true

--- a/src/helpers/ensure_directories.sh
+++ b/src/helpers/ensure_directories.sh
@@ -13,8 +13,6 @@ mkdir -p "$LOG_DIR" && chmod 775 "$LOG_DIR" && chown -R vcap "$LOG_DIR"
 mkdir -p "$RUN_DIR" && chmod 775 "$RUN_DIR" && chown -R vcap "$RUN_DIR"
 mkdir -p "$TMP_DIR" && chmod 775 "$TMP_DIR" && chown -R vcap "$TMP_DIR"
 mkdir -p "$CONFD_DIR" && chmod 775 "$CONFD_DIR" && chown -R vcap "$CONFD_DIR"
-# Add execute flags to any directory inside the bpm run folder, so that the agent can read pidfiles inside
-find /var/vcap/sys/run/bpm -type d -print0 | xargs -0 chmod +x || true
 
 set +e
 set +u


### PR DESCRIPTION
## What does this PR do?
Moves the `chmod +x` on `/var/vcap/sys/run/bpm` directories from `pre-start` (via `ensure_directories.sh`) to a new BOSH `post-start` hook.

## Motivation
`pre-start` runs before BPM jobs start, so the per-job subdirectories under `/var/vcap/sys/run/bpm` don't exist yet. This means newly added BPM jobs (process_agent, trace_agent, system_probe, etc.) won't have the execute bit set on first boot, breaking the agent's ability to read pidfiles. Running it in `post-start` guarantees all BPM job directories are present and covers any future BPM job added to this release without further changes.

## Verification
Deploy the release with BPM enabled and confirm the agent can read pidfiles from all BPM-managed processes on first boot.