### PR TITLE
ci: build a dev release in the validate workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,9 @@ jobs:
       - name: Run prepare script
         run: ./scripts/prepare.sh
 
-      - name: Run build script
-        env:
-          VERSION: 0.0.0-ci-test
-        run: ./scripts/build.sh
+      - name: Create dev release
+        run: |
+          bosh create-release --force --tarball=datadog-agent-release.tgz --name datadog-agent --version 0.0.0-ci-test
 
       - name: Verify build artifact
         run: |


### PR DESCRIPTION
## What does this PR do?
Changes the Validate workflow to build a BOSH **dev** release instead of a **final** release.

## Motivation
The workflow ran `scripts/build.sh`, which does `bosh create-release --final`. A final release must upload any new job/package blob to the blobstore, but CI writes an empty `config/private.yml` and the blobstore is read-only. So every PR that changes job-template or package content fails with:

```
the client operates in read only mode. Change 'credentials_source' parameter value
```

A dev release stores new blobs locally in `.dev_builds`, so it validates that the release assembles without needing blobstore write access. `scripts/build.sh` is left untouched because it is used by other tooling (releasing).

## Verification
- The "Create dev release" step produces `datadog-agent-release.tgz` and the existing "Verify build artifact" step passes.
- Open a PR that touches a job template or package file and confirm Validate is green (previously it failed at the upload step).